### PR TITLE
(Fix) deploy secondary contracts fix

### DIFF
--- a/scripts/deploy-secondary-contracts
+++ b/scripts/deploy-secondary-contracts
@@ -8,5 +8,5 @@ directory=./submodules/poa-network-consensus-contracts
 consensus="0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
 moc_object=$(cat ./keys/moc/moc.key) 
 moc=$(node -pe 'JSON.parse(process.argv[1]).address' "${moc_object}")
-cmd=$(cd ${directory} && SAVE_TO_FILE=true POA_NETWORK_CONSENSUS_ADDRESS=${consensus} MASTER_OF_CEREMONY=${moc} ./node_modules/.bin/truffle migrate --reset --network sokol)
+cmd=$(cd ${directory} && SAVE_TO_FILE=true POA_NETWORK_CONSENSUS_ADDRESS=${consensus} MASTER_OF_CEREMONY=${moc} ./node_modules/.bin/truffle migrate --network sokol)
 #echo ${cmd}

--- a/scripts/prepare-contracts-repo
+++ b/scripts/prepare-contracts-repo
@@ -22,11 +22,11 @@ directory=./submodules/poa-network-consensus-contracts
 # 	fi
 # fi
 
-cmd=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/PoaNetworkConsensus.sol ${directory_flat})
-cmd2=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/KeysManager.sol ${directory_flat})
-cmd3=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/VotingToChangeKeys.sol ${directory_flat})
-cmd4=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/VotingToChangeMinThreshold.sol ${directory_flat})
-cmd5=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/ValidatorMetadata.sol ${directory_flat})
-cmd6=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/ProxyStorage.sol ${directory_flat})
-cmd7=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/VotingToChangeProxyAddress.sol ${directory_flat})
+cmd1=$(cd ${flattener_directory} && npm i && npm start ${directory_contracts}/PoaNetworkConsensus.sol ${directory_flat})
+cmd2=$(cd ${flattener_directory} && npm start ${directory_contracts}/KeysManager.sol ${directory_flat})
+cmd3=$(cd ${flattener_directory} && npm start ${directory_contracts}/VotingToChangeKeys.sol ${directory_flat})
+cmd4=$(cd ${flattener_directory} && npm start ${directory_contracts}/VotingToChangeMinThreshold.sol ${directory_flat})
+cmd5=$(cd ${flattener_directory} && npm start ${directory_contracts}/ValidatorMetadata.sol ${directory_flat})
+cmd6=$(cd ${flattener_directory} && npm start ${directory_contracts}/ProxyStorage.sol ${directory_flat})
+cmd7=$(cd ${flattener_directory} && npm start ${directory_contracts}/VotingToChangeProxyAddress.sol ${directory_flat})
 cmd8=$(cd ${directory} && npm i && ./node_modules/.bin/truffle compile)


### PR DESCRIPTION
- remove `--reset` option for launching of Truffle migration
- no need `npm i` before creating flat file for each contact 