### PR TITLE
(Refactor) Complement prepareGovernanceDapp.js to use core branch instead of demo in Voting DApp

### DIFF
--- a/e2eGovernanceTest.js
+++ b/e2eGovernanceTest.js
@@ -160,7 +160,7 @@ async function main() {
 
     votingPage.clickAlertOKButton();
 
-    driver.sleep(5000);
+    driver.sleep(15000);
 
     let handles = await driver.getAllWindowHandles();
     for (let i = 0; i < handles.length; i++) {

--- a/prepareGovernanceDapp.js
+++ b/prepareGovernanceDapp.js
@@ -72,5 +72,13 @@ const local = {
 	dappHelpersContent = dappHelpersContent.replace(lastGetABI, lastGetABI + abiAddition);
 	fs.writeFileSync(dappHelpers, dappHelpersContent);
 
+	// Change some constants
+	const dappConstants = `${constants.pathToGovernanceDAppRepo}/src/constants.js`;
+	let dappConstantsContent = fs.readFileSync(dappConstants, 'utf8');
+	dappConstantsContent = dappConstantsContent.replace('constants.minBallotDurationInDays = 2;', 'constants.minBallotDurationInDays = 0;');
+	dappConstantsContent = dappConstantsContent.replace('constants.startTimeOffsetInMinutes = 5;', 'constants.startTimeOffsetInMinutes = 1;');
+	dappConstantsContent = dappConstantsContent.replace('constants.endTimeDefaultInMinutes = 2890;', 'constants.endTimeDefaultInMinutes = 3;');
+	fs.writeFileSync(dappConstants, dappConstantsContent);
+
 	console.log("Governance Repo is prepared");
 }


### PR DESCRIPTION
- (Mandatory) Description
This PR updates `prepareGovernanceDapp.js` script to make `poa-test-setup` be able to use `core` branch in Voting DApp. Relates to https://github.com/poanetwork/poa-dapps-voting/issues/118.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Refactor)