### PR TITLE
(Fix) Add KEYS_MANAGER_ADDRESS to prepareGovernanceDapp.js

### DIFF
--- a/prepareGovernanceDapp.js
+++ b/prepareGovernanceDapp.js
@@ -17,6 +17,7 @@ const local = {
     "VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS": "${addresses.VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS}",
     "VOTING_TO_CHANGE_PROXY_ADDRESS": "${addresses.VOTING_TO_CHANGE_PROXY_ADDRESS}",
     "BALLOTS_STORAGE_ADDRESS": "${addresses.BALLOTS_STORAGE_ADDRESS}",
+    "KEYS_MANAGER_ADDRESS": "${addresses.KEYS_MANAGER_ADDRESS}",
     "METADATA_ADDRESS": "${addresses.METADATA_ADDRESS}",
     "PROXY_ADDRESS": "${addresses.PROXY_ADDRESS}",
     "POA_ADDRESS": "${constants.poaNetworkConsensusContractAddress}",


### PR DESCRIPTION
- (Mandatory) Description
`KEYS_MANAGER_ADDRESS` was added in `prepareGovernanceDapp.js`. It will be needed by `poa-test-setup` for Governance DApp testing after https://github.com/poanetwork/poa-dapps-voting/pull/165 is merged.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)