### PR TITLE
(Feature) Check Parity client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -939,14 +939,19 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.0.tgz",
+          "integrity": "sha512-tQkHS8VVxWbrjnNDXgt7/+SuPJ7qDvD0Y2e6bLtoQluR2SPvlmPUcfcU75L1KAalhqULlIFJlJ6BDfnYyJxJsw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000925",
-            "electron-to-chromium": "^1.3.96",
+            "caniuse-lite": "^1.0.30000928",
+            "electron-to-chromium": "^1.3.100",
             "node-releases": "^1.1.3"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000929",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+          "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
         }
       }
     },
@@ -4291,13 +4296,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -4306,9 +4311,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -4567,12 +4572,12 @@
           }
         },
         "browserslist": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.0.tgz",
+          "integrity": "sha512-tQkHS8VVxWbrjnNDXgt7/+SuPJ7qDvD0Y2e6bLtoQluR2SPvlmPUcfcU75L1KAalhqULlIFJlJ6BDfnYyJxJsw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000925",
-            "electron-to-chromium": "^1.3.96",
+            "caniuse-lite": "^1.0.30000928",
+            "electron-to-chromium": "^1.3.100",
             "node-releases": "^1.1.3"
           }
         },
@@ -4586,6 +4591,11 @@
             "lodash.memoize": "^4.1.2",
             "lodash.uniq": "^4.5.0"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000929",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+          "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -4698,13 +4708,13 @@
           "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "postcss-calc": {
@@ -4951,9 +4961,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -5028,13 +5038,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -5043,9 +5053,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -5509,9 +5519,9 @@
       }
     },
     "dir-glob": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.0.tgz",
-      "integrity": "sha512-YqrO+bduKFqPgspvpjDAaKk0qhmvY+SY7NjIRljCDAy6CX7Ft65irIduHbrYXhy+BxJnYKjWuREw6X42w9/+DQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.1.tgz",
+      "integrity": "sha512-UN6X6XwRjllabfRhBdkVSo63uurJ8nSvMGrwl94EYVz6g+exhTV+yVSYk5VC/xl3MBFBTtC0J20uFKce4Brrng==",
       "requires": {
         "path-type": "^3.0.0"
       },
@@ -10928,9 +10938,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -11180,9 +11190,9 @@
       "integrity": "sha512-wlEBIZ5LP8usDylWbDNhKPEFVFdI5hCHpnVoT/Ysvoi/PRhJENm/Rlh9TvjYB38HFfKZN7OzEbRjmjvLkFw11g=="
     },
     "js-levenshtein": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.5.tgz",
-      "integrity": "sha512-ap2aTez3WZASzMmJvgvG+nsrCCrtHPQ+4YB+WQjYQpXgLkM+WqwkpzdlVs5l7Xhk128I/CisIk4CdXl7pIchUA=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
     "js-sha3": {
       "version": "0.6.1",
@@ -13301,13 +13311,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -13316,9 +13326,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -14156,12 +14166,12 @@
           }
         },
         "browserslist": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.0.tgz",
+          "integrity": "sha512-tQkHS8VVxWbrjnNDXgt7/+SuPJ7qDvD0Y2e6bLtoQluR2SPvlmPUcfcU75L1KAalhqULlIFJlJ6BDfnYyJxJsw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000925",
-            "electron-to-chromium": "^1.3.96",
+            "caniuse-lite": "^1.0.30000928",
+            "electron-to-chromium": "^1.3.100",
             "node-releases": "^1.1.3"
           }
         },
@@ -14196,6 +14206,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000929",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+          "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
         },
         "case-sensitive-paths-webpack-plugin": {
           "version": "2.1.2",
@@ -14377,9 +14392,9 @@
           }
         },
         "eslint-config-prettier": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz",
-          "integrity": "sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.5.0.tgz",
+          "integrity": "sha512-LcZEoAY5lL3/H2NTFSeUl/z8X8oMea1IxLEIb5uDbRxPTdQeeT7oGpRWT6UwHXGcoRbYH0TZmfRsh8iXbpyW7A==",
           "requires": {
             "get-stdin": "^6.0.0"
           }
@@ -15462,13 +15477,13 @@
               }
             },
             "postcss": {
-              "version": "7.0.8",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-              "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+              "version": "7.0.13",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+              "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
               "requires": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
-                "supports-color": "^6.0.0"
+                "supports-color": "^6.1.0"
               }
             },
             "source-map": {
@@ -15477,9 +15492,9 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-              "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
               "requires": {
                 "has-flag": "^3.0.0"
               }
@@ -15527,13 +15542,13 @@
               }
             },
             "postcss": {
-              "version": "7.0.8",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-              "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+              "version": "7.0.13",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+              "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
               "requires": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
-                "supports-color": "^6.0.0"
+                "supports-color": "^6.1.0"
               }
             },
             "source-map": {
@@ -15542,9 +15557,9 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-              "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
               "requires": {
                 "has-flag": "^3.0.0"
               }
@@ -15848,27 +15863,6 @@
           "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "requires": {
             "punycode": "^2.1.0"
-          }
-        },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-          "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.13.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-            }
           }
         },
         "uglifyjs-webpack-plugin": {
@@ -16451,11 +16445,6 @@
             "readdirp": "^2.0.0",
             "upath": "^1.0.5"
           }
-        },
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
         },
         "css-loader": {
           "version": "0.28.11",
@@ -17214,22 +17203,6 @@
             "uglify-es": "^3.3.9"
           }
         },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-          "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-            }
-          }
-        },
         "warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -17554,12 +17527,12 @@
       }
     },
     "postcss-attribute-case-insensitive": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.0.tgz",
-      "integrity": "sha512-K/zqdg0/UgUgC8qR0lDuxYzmowPpnvrrNC5YuoqzhHMubR9AuhsPlpVu3jjkLHgDAzR+ohD/m7//iGnN9WxbzQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
+      "integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
       "requires": {
         "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
+        "postcss-selector-parser": "^5.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17596,13 +17569,13 @@
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -17621,9 +17594,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -17704,13 +17677,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -17719,9 +17692,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -17766,13 +17739,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -17781,9 +17754,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -17829,13 +17802,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -17844,9 +17817,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -17891,13 +17864,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -17906,9 +17879,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18023,13 +17996,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18038,9 +18011,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18085,13 +18058,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18100,9 +18073,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18152,13 +18125,13 @@
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -18177,9 +18150,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18229,13 +18202,13 @@
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -18254,9 +18227,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18472,13 +18445,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18487,9 +18460,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18575,13 +18548,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18590,9 +18563,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18636,13 +18609,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18651,9 +18624,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18697,13 +18670,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18712,9 +18685,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18758,13 +18731,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18773,9 +18746,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18820,13 +18793,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18835,9 +18808,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18882,13 +18855,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18897,9 +18870,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -18945,13 +18918,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -18960,9 +18933,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19046,13 +19019,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19061,9 +19034,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19107,13 +19080,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19122,9 +19095,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19470,13 +19443,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19485,9 +19458,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19567,13 +19540,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19582,9 +19555,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19631,13 +19604,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19646,9 +19619,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19695,13 +19668,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19710,9 +19683,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19758,13 +19731,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19773,9 +19746,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19821,13 +19794,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19836,9 +19809,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19864,14 +19837,19 @@
           }
         },
         "browserslist": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.0.tgz",
+          "integrity": "sha512-tQkHS8VVxWbrjnNDXgt7/+SuPJ7qDvD0Y2e6bLtoQluR2SPvlmPUcfcU75L1KAalhqULlIFJlJ6BDfnYyJxJsw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000925",
-            "electron-to-chromium": "^1.3.96",
+            "caniuse-lite": "^1.0.30000928",
+            "electron-to-chromium": "^1.3.100",
             "node-releases": "^1.1.3"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000929",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+          "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -19894,13 +19872,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -19909,9 +19887,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19993,13 +19971,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20008,9 +19986,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20089,13 +20067,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20104,9 +20082,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20150,13 +20128,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20165,9 +20143,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20212,13 +20190,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20227,9 +20205,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20284,26 +20262,40 @@
           }
         },
         "autoprefixer": {
-          "version": "9.4.4",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
-          "integrity": "sha512-7tpjBadJyHKf+gOJEmKhZIksWxdZCSrnKbbTJNsw+/zX9+f//DLELRQPWjjjVoDbbWlCuNRkN7RfmZwDVgWMLw==",
+          "version": "9.4.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.5.tgz",
+          "integrity": "sha512-M602C0ZxzFpJKqD4V6eq2j+K5CkzlhekCrcQupJmAOrPEZjWJyj/wSeo6qRSNoN6M3/9mtLPQqTTrABfReytQg==",
           "requires": {
-            "browserslist": "^4.3.7",
-            "caniuse-lite": "^1.0.30000926",
+            "browserslist": "^4.4.0",
+            "caniuse-lite": "^1.0.30000928",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
-            "postcss": "^7.0.7",
+            "postcss": "^7.0.11",
             "postcss-value-parser": "^3.3.1"
+          },
+          "dependencies": {
+            "caniuse-lite": {
+              "version": "1.0.30000929",
+              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+              "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
+            }
           }
         },
         "browserslist": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.0.tgz",
+          "integrity": "sha512-tQkHS8VVxWbrjnNDXgt7/+SuPJ7qDvD0Y2e6bLtoQluR2SPvlmPUcfcU75L1KAalhqULlIFJlJ6BDfnYyJxJsw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000925",
-            "electron-to-chromium": "^1.3.96",
+            "caniuse-lite": "^1.0.30000928",
+            "electron-to-chromium": "^1.3.100",
             "node-releases": "^1.1.3"
+          },
+          "dependencies": {
+            "caniuse-lite": {
+              "version": "1.0.30000929",
+              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+              "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
+            }
           }
         },
         "chalk": {
@@ -20327,13 +20319,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20342,9 +20334,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20394,13 +20386,13 @@
           "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -20419,9 +20411,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20570,13 +20562,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20585,9 +20577,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20631,13 +20623,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20646,9 +20638,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20693,13 +20685,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20708,9 +20700,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20755,13 +20747,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -20770,9 +20762,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -20868,9 +20860,9 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "postcss-values-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.0.tgz",
-      "integrity": "sha512-cyRdkgbRRefu91ByAlJow4y9w/hnBmmWgLpWmlFQ2bpIy2eKrqowt3VeYcaHQ08otVXmC9V2JtYW1Z/RpvYR8A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+      "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
       "requires": {
         "flatten": "^1.0.2",
         "indexes-of": "^1.0.1",
@@ -21757,9 +21749,9 @@
       }
     },
     "react-select": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
-      "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.2.1.tgz",
+      "integrity": "sha512-vaCgT2bEl+uTyE/uKOEgzE5Dc/wLtzhnBvoHCeuLoJWc4WuadN6WQDhoL42DW+TziniZK2Gaqe/wUXydI3NSaQ==",
       "requires": {
         "classnames": "^2.2.4",
         "prop-types": "^15.5.8",
@@ -22621,9 +22613,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.5.tgz",
-      "integrity": "sha512-2mgiX2VOarcQv8G40WdJ5QJniYdsPr0yGedkd98PqApodsS9DG29qyHl/X65OILm7Bapd1/zUUvTHVZwNLhXvQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.6.tgz",
+      "integrity": "sha512-LAYs+lChg1v5uKNzPtsgTxSS5hLo8aIhSMCJt1WMpefAxm3D1RTpMwSpb6ebdL31cubiLTnhokVktBW+cv9Y9w==",
       "requires": {
         "xmlchars": "^1.3.1"
       }
@@ -23588,14 +23580,19 @@
           }
         },
         "browserslist": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-          "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.0.tgz",
+          "integrity": "sha512-tQkHS8VVxWbrjnNDXgt7/+SuPJ7qDvD0Y2e6bLtoQluR2SPvlmPUcfcU75L1KAalhqULlIFJlJ6BDfnYyJxJsw==",
           "requires": {
-            "caniuse-lite": "^1.0.30000925",
-            "electron-to-chromium": "^1.3.96",
+            "caniuse-lite": "^1.0.30000928",
+            "electron-to-chromium": "^1.3.100",
             "node-releases": "^1.1.3"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000929",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+          "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -23618,13 +23615,13 @@
           }
         },
         "postcss": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.8.tgz",
-          "integrity": "sha512-WudsIzuTKRw9IInRTPBgVXJ7DKR26HT09Rxp0g3w0Fqh3TUtYICcUmvC0xURj04o3vdcDtnjCAUCECg/p341iQ==",
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+          "integrity": "sha512-h8SY6kQTd1wISHWjz+E6cswdhMuyBZRb16pSTv3W4zYZ3/YbyWeJdNUeOXB5IdZqE1U76OUEjjjqsC3z2f3hVg==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^6.0.0"
+            "supports-color": "^6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -23643,9 +23640,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -23991,9 +23988,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -24461,6 +24458,27 @@
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
       "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+    },
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "requires": {
+        "commander": "~2.13.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "get-all-submodules": "git submodule update --init --remote",
     "prepare-contracts-repo": "bash ./scripts/prepare-contracts-repo",
     "prepare-moc-node": "node prepareMoCNode",
-    "start-moc-node": "bash ./scripts/start-moc-node > /dev/null 2>&1 &",
+    "start-moc-node": "bash ./scripts/start-moc-node",
     "deploy-secondary-contracts": "bash ./scripts/deploy-secondary-contracts",
     "prepare-scripts-moc-repo": "node prepareMoCScripts",
     "prepare-ceremony-dapp": "node prepareCeremonyDapp",

--- a/scripts/deploy-secondary-contracts
+++ b/scripts/deploy-secondary-contracts
@@ -8,5 +8,9 @@ directory=./submodules/poa-network-consensus-contracts
 consensus="0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
 moc_object=$(cat ./keys/moc/moc.key) 
 moc=$(node -pe 'JSON.parse(process.argv[1]).address' "${moc_object}")
-cmd=$(cd ${directory} && DEMO=true SAVE_TO_FILE=true POA_NETWORK_CONSENSUS_ADDRESS=${consensus} MASTER_OF_CEREMONY=${moc} ./node_modules/.bin/truffle migrate --network sokol)
-#echo ${cmd}
+cmd=$(cd ${directory} \
+ && DEMO=true SAVE_TO_FILE=true \
+ POA_NETWORK_CONSENSUS_ADDRESS=${consensus} \
+ MASTER_OF_CEREMONY=${moc} \
+ ./node_modules/.bin/truffle migrate --network sokol)
+echo ${cmd}

--- a/scripts/start-moc-node
+++ b/scripts/start-moc-node
@@ -1,11 +1,20 @@
 #!/bin/bash
-
 set -u
 set -e
 
-parityDebPath=./parity_1.9.2_amd64.deb
-if ! [ -x "$(command -v parity)" ]; then
-  cmd=$(sudo dpkg -i ${parityDebPath})
+source ./scripts/utils.sh
+
+res=$(checkclientversion)
+
+if [ ! -z "$res" -a "$res" != " " ]
+then
+	echo $res
+	exit 1
 fi
 
-cmd2=$(parity --config ./nodes/parity-moc/moc.toml > ./nodes/parity-moc/parity.log 2>&1)
+toml=./nodes/parity-moc/moc.toml
+log=./nodes/parity-moc/parity.log
+
+cmd2=$(parity --config $toml > $log > /dev/null 2>&1 &)
+
+exit 0

--- a/scripts/start-validator-node
+++ b/scripts/start-validator-node
@@ -1,12 +1,22 @@
 #!/bin/bash
-
 set -u
 set -e
 
-validator_num=$1
-parityDebPath=./parity_1.9.2_amd64.deb
-if ! [ -x "$(command -v parity)" ]; then
-  cmd=$(sudo dpkg -i ${parityDebPath})
+source ./scripts/utils.sh
+
+res=$(checkclientversion)
+
+if [ ! -z "$res" -a "$res" != " " ]
+then
+	echo $res
+	exit 1
 fi
 
-cmd2=$(parity --config ./nodes/parity_validator_${validator_num}/node.toml > ./nodes/parity_validator_${validator_num}/parity.log 2>&1 &)
+validator_num=$1
+
+toml=./nodes/parity_validator_${validator_num}/node.toml
+log=./nodes/parity_validator_${validator_num}/parity.log
+
+cmd2=$(parity --config $toml > $log > /dev/null 2>&1 &)
+
+exit 0

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function checkclientversion()
+{
+	parityversionoutput=$(parity --version)
+
+	parityversion=$(echo $parityversionoutput | cut -d'-' -f 2 | cut -d'/' -f 2 | cut -d'v' -f 2) 
+	major=$(echo $parityversion | cut -d'.' -f 1)
+	minor=$(echo $parityversion | cut -d'.' -f 2)
+	patch=$(echo $parityversion | cut -d'.' -f 3)
+
+	majormin=1
+	minormin=9
+	patchmin=2
+
+	errormsg="Parity Ethereum client version should be more or equal than v1.9.2. Your current installation has version $parityversion"
+
+	function genError()
+	{
+		echo $errormsg
+		exit 0
+	}
+
+	if [ $major -lt $majormin ];
+	then
+		genError
+	elif [ $major -eq $majormin ] && [ $minor -lt $minormin ];
+	then
+		genError
+	elif [ $major -eq $majormin ] && [ $minor -eq $minormin ] && [ $patch -lt $patchmin ];
+	then
+		genError
+	fi
+
+	echo ""
+	exit 0
+}


### PR DESCRIPTION
Closes https://github.com/poanetwork/poa-test-setup/issues/66

- Check Parity client version. It should be more than **1.9.2**. If the client version is lower, then the script throws an error.
- Remove trying to install Parity client from deb package.