### PR TITLE
Ignore nodes configuration data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ typings/
 .env
 
 .DS_Store
+
+# Nodes data
+nodes/parity-moc
+nodes/parity_validator_*
+keys
+spec/spec.json


### PR DESCRIPTION
I updated `.gitignore` with nodes configuration data:
- Keys
- spec.json
- moc and validators data

I think they should be ignored because they are not related to source code and they changes everytime someone setups a new POA chain with this project.