### PR TITLE
Support updated Voting DApp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17852,8 +17852,8 @@
       }
     },
     "poa-dapps-voting": {
-      "version": "github:poanetwork/poa-dapps-voting#27655e420f32575bc1341a87089688b15ab68948",
-      "from": "github:poanetwork/poa-dapps-voting#27655e420f32575bc1341a87089688b15ab68948",
+      "version": "github:poanetwork/poa-dapps-voting#eb88e99620545af26163810919449b41d092f5a3",
+      "from": "github:poanetwork/poa-dapps-voting#eb88e99620545af26163810919449b41d092f5a3",
       "requires": {
         "ajv": "6.5.2",
         "autoprefixer": "7.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17852,8 +17852,8 @@
       }
     },
     "poa-dapps-voting": {
-      "version": "github:poanetwork/poa-dapps-voting#eb88e99620545af26163810919449b41d092f5a3",
-      "from": "github:poanetwork/poa-dapps-voting#eb88e99620545af26163810919449b41d092f5a3",
+      "version": "github:poanetwork/poa-dapps-voting#1cecd5d169078e56df6613153abf86d1bd1e8211",
+      "from": "github:poanetwork/poa-dapps-voting#1cecd5d169078e56df6613153abf86d1bd1e8211",
       "requires": {
         "ajv": "6.5.2",
         "autoprefixer": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "path": "^0.12.7",
     "poa-dapps-keys-generation": "github:poanetwork/poa-dapps-keys-generation#cae6121305bf9d67ce15d7b46f2886552941cee2",
     "poa-dapps-validators": "github:poanetwork/poa-dapps-validators#a1c023202d28f66d3331d1997c1879d9fadbaf88",
-    "poa-dapps-voting": "github:poanetwork/poa-dapps-voting#eb88e99620545af26163810919449b41d092f5a3",
+    "poa-dapps-voting": "github:poanetwork/poa-dapps-voting#1cecd5d169078e56df6613153abf86d1bd1e8211",
     "selenium-webdriver": "3.6.0",
     "toml": "^2.3.3",
     "toml-js": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "path": "^0.12.7",
     "poa-dapps-keys-generation": "github:poanetwork/poa-dapps-keys-generation#cae6121305bf9d67ce15d7b46f2886552941cee2",
     "poa-dapps-validators": "github:poanetwork/poa-dapps-validators#a1c023202d28f66d3331d1997c1879d9fadbaf88",
-    "poa-dapps-voting": "github:poanetwork/poa-dapps-voting#27655e420f32575bc1341a87089688b15ab68948",
+    "poa-dapps-voting": "github:poanetwork/poa-dapps-voting#eb88e99620545af26163810919449b41d092f5a3",
     "selenium-webdriver": "3.6.0",
     "toml": "^2.3.3",
     "toml-js": "0.0.8",

--- a/prepareGovernanceDapp.js
+++ b/prepareGovernanceDapp.js
@@ -83,6 +83,14 @@ const local = {
 	dappHelpersContent = dappHelpersContent.replace(lastGetABI, lastGetABI + abiAddition);
 	fs.writeFileSync(dappHelpers, dappHelpersContent);
 
+	const dappGetWeb3 = `${constants.pathToGovernanceDAppRepo}/src/utils/getWeb3.js`;
+	let dappGetWeb3Content = fs.readFileSync(dappGetWeb3, 'utf8');
+	function replaceDefaultNetId(network) {
+		return `const defaultNetId = helpers.netIdByBranch(constants.${network})`
+	}
+	dappGetWeb3Content = dappGetWeb3Content.replace(replaceDefaultNetId('CORE'), replaceDefaultNetId('SOKOL'));
+	fs.writeFileSync(dappGetWeb3, dappGetWeb3Content);
+
 	// Change some constants
 	const dappConstants = `${constants.pathToGovernanceDAppRepo}/src/utils/constants.js`;
 	let dappConstantsContent = fs.readFileSync(dappConstants, 'utf8');


### PR DESCRIPTION
These changes are for adding the support of the updated Voting DApp. Should be merged after https://github.com/poanetwork/poa-dapps-voting/pull/203 is merged.

`package.json` and `package-lock.json` use the commit https://github.com/poanetwork/poa-dapps-voting/commit/1cecd5d169078e56df6613153abf86d1bd1e8211

If there are new commits in https://github.com/poanetwork/poa-dapps-voting/pull/203, the hash of the latest commit should be correspondingly updated in `package.json` and `package-lock.json`.

Please recheck the commit hash for Voting DApp in `package.json` file and use `Squash and merge` when merging this PR.